### PR TITLE
Add HTML parsing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# screen_bug_free_stks
+# Screener HTML Parser
+
+This repository contains a simple parser for extracting tables from screener.in HTML pages.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install beautifulsoup4
+   ```
+
+2. Run the parser on an HTML file:
+   ```bash
+   python parse_screener.py path/to/page.html
+   ```
+
+This will produce three CSV files in the current directory:
+
+- `bulk_deals.csv`
+- `block_deals.csv`
+- `shareholdings.csv`
+
+Sample HTML is provided in `data/sample.html` for testing.

--- a/data/sample.html
+++ b/data/sample.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Government Of Singapore - Investments - Screener</title>
+</head>
+<body>
+<div id="bulk-deals" class="card card-medium">
+  <h2>Bulk Deals</h2>
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th class="text">Company</th>
+        <th></th>
+        <th>Quantity</th>
+        <th>Price</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="stripe">
+        <td class="text">
+          <a href="/company/PGEL/consolidated/">PG Electroplast</a>
+          <br>
+          <span class="font-size-12 font-weight-500 nowrap sub">27 May, 2025</span>
+        </td>
+        <td class="sub">B</td>
+        <td>38,18,522</td>
+        <td>755</td>
+      </tr>
+      <tr>
+        <td class="text">
+          <a href="/company/DATAPATTNS/">Data Pattern</a>
+          <br>
+          <span class="font-size-12 font-weight-500 nowrap sub">21 May, 2025</span>
+        </td>
+        <td class="sub">SELL</td>
+        <td>2,84,964</td>
+        <td>2,729</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div id="block-deals" class="card card-medium">
+  <h2>Block Deals</h2>
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th class="text">Company</th>
+        <th></th>
+        <th>Quantity</th>
+        <th>Price</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="stripe">
+        <td class="text">
+          <a href="/company/PNBHOUSING/">PNB Housing</a>
+          <br>
+          <span class="font-size-12 font-weight-500 nowrap sub">12 Sep, 2024</span>
+        </td>
+        <td class="sub">BUY</td>
+        <td>13,16,168</td>
+        <td>1,097</td>
+      </tr>
+      <tr>
+        <td class="text">
+          <a href="/company/KALYANKJIL/consolidated/">Kalyan Jewellers</a>
+          <br>
+          <span class="font-size-12 font-weight-500 nowrap sub">22 Aug, 2024</span>
+        </td>
+        <td class="sub">BUY</td>
+        <td>72,51,796</td>
+        <td>539</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div id="shareholdings" class="card card-large">
+  <h2>Shareholding</h2>
+  <table class="data-table mark-visited">
+    <thead>
+      <tr>
+        <th class="text"></th>
+        <th>Mar 2024</th>
+        <th>Jun 2024</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="stripe">
+        <td class="text"><a href="/company/AAVAS/">AAVAS Financiers</a></td>
+        <td>2.99</td>
+        <td>2.76</td>
+      </tr>
+      <tr>
+        <td class="text"><a href="/company/ACUTAAS/consolidated/">Acutaas Chemical</a></td>
+        <td>1.14</td>
+        <td>2.05</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/parse_screener.py
+++ b/parse_screener.py
@@ -1,0 +1,89 @@
+import csv
+from bs4 import BeautifulSoup
+import sys
+
+
+def parse_bulk_block_table(table):
+    rows = []
+    for tr in table.select('tbody tr'):
+        cols = tr.find_all('td')
+        if not cols:
+            continue
+        company = cols[0].get_text(strip=True, separator=' ')
+        # extract date from span inside first td
+        date_span = cols[0].find('span')
+        date = date_span.get_text(strip=True) if date_span else ''
+        # remove date from company text
+        if date:
+            company = company.replace(date, '').strip()
+        txn_type = cols[1].get_text(strip=True)
+        quantity = cols[2].get_text(strip=True)
+        price = cols[3].get_text(strip=True)
+        rows.append({
+            'Company': company,
+            'Date': date,
+            'Type': txn_type,
+            'Quantity': quantity,
+            'Price': price,
+        })
+    return rows
+
+
+def parse_shareholding_table(table):
+    header_cells = table.select_one('thead tr').find_all('th')
+    headers = ['Company'] + [th.get_text(strip=True) for th in header_cells[1:]]
+    data = []
+    for tr in table.select('tbody tr'):
+        cells = tr.find_all('td')
+        if not cells:
+            continue
+        row = [cells[0].get_text(strip=True)]
+        for td in cells[1:]:
+            row.append(td.get_text(strip=True))
+        # ensure row has same length as headers
+        while len(row) < len(headers):
+            row.append('')
+        data.append(dict(zip(headers, row)))
+    return headers, data
+
+
+def main(html_path):
+    with open(html_path, 'r', encoding='utf-8') as f:
+        soup = BeautifulSoup(f, 'html.parser')
+
+    # Bulk deals
+    bulk_div = soup.find('div', id='bulk-deals')
+    if bulk_div:
+        bulk_table = bulk_div.find('table')
+        bulk_rows = parse_bulk_block_table(bulk_table)
+        with open('bulk_deals.csv', 'w', newline='', encoding='utf-8') as f:
+            writer = csv.DictWriter(f, fieldnames=['Company', 'Date', 'Type', 'Quantity', 'Price'])
+            writer.writeheader()
+            writer.writerows(bulk_rows)
+
+    # Block deals
+    block_div = soup.find('div', id='block-deals')
+    if block_div:
+        block_table = block_div.find('table')
+        block_rows = parse_bulk_block_table(block_table)
+        with open('block_deals.csv', 'w', newline='', encoding='utf-8') as f:
+            writer = csv.DictWriter(f, fieldnames=['Company', 'Date', 'Type', 'Quantity', 'Price'])
+            writer.writeheader()
+            writer.writerows(block_rows)
+
+    # Shareholding
+    share_div = soup.find('div', id='shareholdings')
+    if share_div:
+        share_table = share_div.find('table')
+        headers, share_rows = parse_shareholding_table(share_table)
+        with open('shareholdings.csv', 'w', newline='', encoding='utf-8') as f:
+            writer = csv.DictWriter(f, fieldnames=headers)
+            writer.writeheader()
+            writer.writerows(share_rows)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage: python parse_screener.py <html_file>')
+        sys.exit(1)
+    main(sys.argv[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+beautifulsoup4


### PR DESCRIPTION
## Summary
- add a Python script `parse_screener.py` for extracting Bulk Deals, Block Deals and Shareholding tables from screener HTML
- add sample HTML and requirements
- document how to run parser

## Testing
- `python3 parse_screener.py data/sample.html`

------
https://chatgpt.com/codex/tasks/task_e_6854b9fcf2b48333966e65d029ca03d9